### PR TITLE
Let CI pipline download lfs files as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Set up Node ⚙
         uses: actions/setup-node@v4


### PR DESCRIPTION
The [README](https://github.com/actions/checkout?tab=readme-ov-file#usage) fo `action/checkout` has an overview of options that include

```
- uses: actions/checkout@v4
  with:
...
    # Whether to download Git-LFS files
    # Default: false
    lfs: ''
```

So I think adding `lfs: true` should fix the issue #66 